### PR TITLE
feat: update `*_INTERNAL_URL` to be the full URL with proto and port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=yourpassword123
       - GF_DEFAULT_INSTANCE_NAME=Grafana
       - GF_INSTALL_PLUGINS=grafana-simple-json-datasource,grafana-piechart-panel,grafana-worldmap-panel,grafana-clock-panel
-      - LOKI_INTERNAL_URL=loki
-      - PROMETHEUS_INTERNAL_URL=prometheus
+      - LOKI_INTERNAL_URL=http://loki:3100
+      - PROMETHEUS_INTERNAL_URL=http://prometheus:9090
 
 volumes: 
   prometheus_data:

--- a/grafana/datasources/datasources.yml
+++ b/grafana/datasources/datasources.yml
@@ -12,8 +12,8 @@ datasources:
     type: loki
     access: direct
     orgId: 1
-    uid: grafana_loki
-    url: http://$LOKI_INTERNAL_URL:3100
+    uid: grafana_lokiq
+    url: $LOKI_INTERNAL_URL
     user:
     database:
     basicAuth:
@@ -25,7 +25,7 @@ datasources:
     access: direct
     orgId: 1
     uid: grafana_prometheus
-    url: http://$PROMETHEUS_INTERNAL_URL:9090
+    url: $PROMETHEUS_INTERNAL_URL
     user:
     database:
     basicAuth:


### PR DESCRIPTION
This pull request includes changes to the configuration of Grafana, Loki, and Prometheus in the `docker-compose.yml` and `grafana/datasources/datasources.yml` files. The most important changes involve updating internal URLs and modifying datasource configurations.