### PR TITLE
feat: working tempo container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,14 +20,23 @@ services:
     volumes:
       - loki_data:/loki
 
+  tempo: 
+    build:
+      context: ./tempo
+      dockerfile: dockerfile
+    ports:
+      - "3200:3200"
+    volumes:
+      - tempo_data:/var/tempo
+
   grafana:
     build:
       context: ./grafana
       dockerfile: dockerfile
     ports:
       - "3000:3000"
-    volumes:
-      - grafana_data:/var/lib/grafana
+    # volumes:
+    #   - grafana_data:/var/lib/grafana
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=yourpassword123
@@ -35,8 +44,10 @@ services:
       - GF_INSTALL_PLUGINS=grafana-simple-json-datasource,grafana-piechart-panel,grafana-worldmap-panel,grafana-clock-panel
       - LOKI_INTERNAL_URL=http://loki:3100
       - PROMETHEUS_INTERNAL_URL=http://prometheus:9090
+      - TEMPO_INTERNAL_URL=http://tempo:3200
 
 volumes: 
   prometheus_data:
   loki_data:
-  grafana_data:
+  # grafana_data:
+  tempo_data:

--- a/grafana/datasources/datasources.yml
+++ b/grafana/datasources/datasources.yml
@@ -32,3 +32,15 @@ datasources:
     basicAuthUser:
     withCredentials:
     isDefault: false
+  - name: Tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    uid: grafana_tempo
+    url: $TEMPO_INTERNAL_URL
+    user:
+    database:
+    basicAuth:
+    basicAuthUser:
+    withCredentials:
+    isDefault: false

--- a/tempo/dockerfile
+++ b/tempo/dockerfile
@@ -1,0 +1,7 @@
+ARG VERSION=latest
+
+FROM grafana/tempo:${VERSION}
+
+COPY tempo.yml /etc/tempo/tempo.yml
+
+CMD ["-config.file=/etc/tempo/tempo.yml"]

--- a/tempo/tempo.yml
+++ b/tempo/tempo.yml
@@ -1,0 +1,21 @@
+server:
+  http_listen_port: 3200
+
+compactor:
+  compaction:
+    compaction_window: 1h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+
+distributor:
+  log_received_spans:
+        enabled: true
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+        http:


### PR DESCRIPTION
This pull request introduces a new Tempo service to the existing Docker Compose setup, along with necessary configurations and files to support it. The most important changes include adding the Tempo service to the `docker-compose.yml`, configuring Grafana to use Tempo as a data source, and creating the necessary Dockerfile and configuration file for Tempo.

### Addition of Tempo Service:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R23-R53): Added a new Tempo service with its build context, ports, and volumes. Updated Grafana's environment variables to include the Tempo internal URL.

### Grafana Configuration:

* [`grafana/datasources/datasources.yml`](diffhunk://#diff-d16f34870781cd6a8006aead52573af32d59d32e14221dbfa95fb8e81080b235R35-R46): Added a new data source configuration for Tempo in Grafana.

### Tempo Configuration:

* [`tempo/dockerfile`](diffhunk://#diff-8fc3e0012eeb18ffa21e4f96602ebb78b219ee8a140594970460fe1b9468141dR1-R7): Created a Dockerfile for Tempo to build the service using the Grafana Tempo image and copy the configuration file.
* [`tempo/tempo.yml`](diffhunk://#diff-385f2185ad25a2249d4c4974fe3f635bc400154a1c66fcea89680a8a141beddaR1-R21): Added a configuration file for Tempo specifying server settings, storage backend, and receiver protocols.