### PR TITLE
feat: add complete example for tempo traces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
       dockerfile: dockerfile
     user: root # required for data persistence
     ports:
-      - "3200:3200"
+      - "3200:3200" # http server for querying
+      - "4317:4317" # grpc server for ingest
+      - "4318:4318" # http server for ingest
     volumes:
       - tempo_data:/var/tempo
 
@@ -55,6 +57,9 @@ services:
       dockerfile: dockerfile
     ports:
       - "9091:9091"
+    environment:
+      - TEMPO_URL=http://tempo:4318
+      - TEMPO_SERVICE_NAME=example_api
 
 volumes: 
   prometheus_data:

--- a/examples/api/index.js
+++ b/examples/api/index.js
@@ -1,10 +1,12 @@
 import express from 'express';
 import promMiddleware from 'express-prometheus-middleware';
+import { trace } from "@opentelemetry/api";
 
 import { logger } from './logger.js';
+import './tracer.js';
+
 
 const app = express();
-
 const PORT = process.env.PORT || 9091;
 
 app.use(promMiddleware({
@@ -13,10 +15,15 @@ app.use(promMiddleware({
   requestDurationBuckets: [0.1, 0.5, 1, 1.5],
 }));
 
+// this creates custom spans to be sent to tempo
+const tracer = trace.getTracer(process.env.TEMPO_SERVICE_NAME || 'unknown')
+
 app.get('/hello', (req, res) => {
+  const span = tracer.startSpan("parse json");
   logger.info('Request to hello endpoint v2');
   const { name = 'Anon' } = req.query;
   res.json({ message: `Hello, ${name}!` });
+  span.end();
 });
 
 app.listen(PORT, () => {

--- a/examples/api/tracer.js
+++ b/examples/api/tracer.js
@@ -1,0 +1,33 @@
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { Resource } from "@opentelemetry/resources";
+
+const tempoUrl = process.env.TEMPO_URL || "http://localhost:4318";
+const tempoIngestAPIUrl = `${tempoUrl}/v1/traces`;
+
+// Configure the trace exporter
+const traceExporter = new OTLPTraceExporter({
+  url: tempoIngestAPIUrl
+});
+
+// Create and register the SDK
+const sdk = new NodeSDK({
+  resource: new Resource({
+    "service.name": process.env.TEMPO_SERVICE_NAME || 'unknown',
+  }),
+  traceExporter: traceExporter,
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+// Initialize the SDK and register with the OpenTelemetry API
+sdk.start();
+
+// Gracefully shut down the SDK on process exit
+process.on("SIGTERM", () => {
+  sdk
+    .shutdown()
+    .then(() => console.log("Tracing terminated"))
+    .catch((error) => console.log("Error terminating tracing", error))
+    .finally(() => process.exit(0));
+});

--- a/tempo/tempo.yml
+++ b/tempo/tempo.yml
@@ -18,4 +18,8 @@ distributor:
     otlp:
       protocols:
         grpc:
+          # this endpoint can be used for sending traces/spans via GRPC
+          endpoint: "0.0.0.0:4317"
         http:
+          # this endpoint can be used for sending traces/spans via HTTP
+          endpoint: "0.0.0.0:4318"


### PR DESCRIPTION
This inclues a proper example of how to use tempo traces in an express app via the OTel API packages.
This should close off #8 