### PR TITLE
fix: tempo regression in v2.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ Examples:
 - Grafana: `VERSION=11.5.2`
 - Loki: `VERSION=3.4.2`
 - Prometheus: `VERSION=v3.2.1`
-- Tempo: `VERSION=v2.7.1`
+- Tempo: `VERSION=2.9.0`
 
 This allows you to update each component independently as needed.
+
+> **⚠️ Note on Tempo v2.10.0**: There is a known issue with Tempo v2.10.0 where the `compactor` configuration block is not recognized, causing startup failures. This template is pinned to v2.9.0 until this issue is resolved in a future release.
 
 ## Project Structure & Services
 

--- a/tempo/dockerfile
+++ b/tempo/dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=latest
+ARG VERSION=2.9.0
 
 FROM grafana/tempo:${VERSION}
 


### PR DESCRIPTION
## Summary of changes
Tempo v2.10.0 has a regression where the compactor configuration block is not recognized, causing the service to fail on startup with the error:

```bash
failed parsing config: failed to parse configFile /etc/tempo/tempo.yml: yaml: unmarshal errors:
  line 4: field compactor not found in type app.Config
```

This fixes #31 

This occurs even though:

- The source code defines the Compactor field
- The official documentation shows compactor as valid configuration
- Grafana's own example configs use this structure

## Solution

Pin Tempo to v2.9.0 in the Dockerfile, which works correctly with the existing configuration.
Changes

- Updated tempo/dockerfile to use VERSION=2.9.0 instead of latest
- Added warning note in README about the v2.10.0 issue
- Updated README example to show 2.9.0 instead of v2.7.1

## Testing
Verified that Tempo v2.9.0 starts successfully with the existing compactor configuration and all services are functioning correctly.

_Once Grafana resolves this issue in a future release (likely v2.10.1 or v2.11.0), we can update the version pin._