### PR TITLE
Configurable scrape interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ This template is perfect for teams who need a comprehensive observability soluti
 | `GF_SECURITY_ADMIN_PASSWORD` | Password for the Grafana admin account | Auto-generated secure string |
 | `GF_DEFAULT_INSTANCE_NAME` | Name of your Grafana instance | `Grafana on Railway` |
 | `GF_INSTALL_PLUGINS` | Comma-separated list of Grafana plugins to install | `grafana-simple-json-datasource,grafana-piechart-panel,grafana-worldmap-panel,grafana-clock-panel` |
+| `PROMETHEUS_SCRAPE_INTERVAL` | How often Prometheus scrapes targets | `15s` |
+| `GF_PROMETHEUS_SCRAPE_INTERVAL` | Minimum scrape interval shown in Grafana dashboards | `15s` |
+| `PROMETHEUS_FLAGS` | Optional runtime flags for Prometheus (e.g. `--web.enable-otlp-receiver`) | _(empty)_ |
 
 ### Internal Service URLs
 
@@ -96,6 +99,8 @@ This template deploys four interconnected services:
 - Time-series database for metrics collection
 - Configured with sensible defaults for monitoring
 - Persistent volume for metrics data
+- Configurable scrape interval via `PROMETHEUS_SCRAPE_INTERVAL` environment variable
+- Support for optional runtime flags via `PROMETHEUS_FLAGS` (e.g. `--web.enable-otlp-receiver`)
 
 ### Loki
 - Log aggregation system designed to be cost-effective

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - "9090:9090"
     volumes:
       - prometheus_data:/prometheus
+    environment:
+      - PROMETHEUS_SCRAPE_INTERVAL=15s
 
   loki:
     build:
@@ -50,6 +52,7 @@ services:
       - LOKI_INTERNAL_URL=http://loki:3100
       - PROMETHEUS_INTERNAL_URL=http://prometheus:9090
       - TEMPO_INTERNAL_URL=http://tempo:3200
+      - GF_PROMETHEUS_SCRAPE_INTERVAL=15s
   
   example_api: 
     build:

--- a/grafana/datasources/datasources.yml
+++ b/grafana/datasources/datasources.yml
@@ -32,6 +32,8 @@ datasources:
     basicAuthUser:
     withCredentials:
     isDefault: false
+    jsonData:
+      timeInterval: $GF_PROMETHEUS_SCRAPE_INTERVAL
   - name: Tempo
     type: tempo
     access: proxy

--- a/grafana/dockerfile
+++ b/grafana/dockerfile
@@ -2,5 +2,8 @@ ARG VERSION=11.5.2
 
 FROM grafana/grafana-oss:${VERSION}
 
+# Default scrape interval for Prometheus datasource
+ENV GF_PROMETHEUS_SCRAPE_INTERVAL=15s
+
 # copy the datasources and dashboards
 COPY datasources /etc/grafana/provisioning/datasources

--- a/prometheus/dockerfile
+++ b/prometheus/dockerfile
@@ -5,5 +5,11 @@ FROM prom/prometheus:${VERSION}
 # Copy the prom.yml configuration file to the container
 COPY prom.yml /etc/prometheus/prom.yml
 
-# Command to run Prometheus
-CMD ["--config.file=/etc/prometheus/prom.yml", "--storage.tsdb.path=/prometheus"]
+# Copy the entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+
+USER root
+RUN chmod +x /entrypoint.sh
+USER nobody
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/prometheus/entrypoint.sh
+++ b/prometheus/entrypoint.sh
@@ -7,4 +7,5 @@ sed "s/\${PROMETHEUS_SCRAPE_INTERVAL}/${PROMETHEUS_SCRAPE_INTERVAL:-15s}/g" \
 # Start Prometheus
 exec /bin/prometheus \
   --config.file=/tmp/prom.yml \
-  --storage.tsdb.path=/prometheus
+  --storage.tsdb.path=/prometheus \
+  $PROMETHEUS_FLAGS

--- a/prometheus/entrypoint.sh
+++ b/prometheus/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Apply environment variables to config (defaults to 15s if not set)
+sed "s/\${PROMETHEUS_SCRAPE_INTERVAL}/${PROMETHEUS_SCRAPE_INTERVAL:-15s}/g" \
+  /etc/prometheus/prom.yml > /tmp/prom.yml
+
+# Start Prometheus
+exec /bin/prometheus \
+  --config.file=/tmp/prom.yml \
+  --storage.tsdb.path=/prometheus

--- a/prometheus/prom.yml
+++ b/prometheus/prom.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 15s # Default scrape interval
+  scrape_interval: ${PROMETHEUS_SCRAPE_INTERVAL} # Default scrape interval
 
 scrape_configs:
   - job_name: 'prometheus'


### PR DESCRIPTION
## Summary
- Make Prometheus scrape interval configurable at runtime via `PROMETHEUS_SCRAPE_INTERVAL` environment variable (defaults to `15s`)
- Make Grafana's Prometheus datasource `timeInterval` configurable via `GF_PROMETHEUS_SCRAPE_INTERVAL` environment variable (defaults to `15s`)
- Add `PROMETHEUS_FLAGS` environment variable to pass optional runtime flags to Prometheus (e.g. `--web.enable-otlp-receiver`)

## Motivation
Hardcoded scrape intervals require a rebuild to change. This PR allows operators to tune scrape intervals and Prometheus feature flags per environment without modifying any config files — just set the environment variable and restart.

## Changes
| File | Change |
|---|---|
| `prometheus/prom.yml` | Replace hardcoded `15s` with `${PROMETHEUS_SCRAPE_INTERVAL}` placeholder |
| `prometheus/entrypoint.sh` | New entrypoint script that substitutes env vars via `sed` and starts Prometheus with optional `$PROMETHEUS_FLAGS` |
| `prometheus/dockerfile` | Use custom entrypoint instead of direct CMD |
| `grafana/datasources/datasources.yml` | Add `jsonData.timeInterval` referencing `$GF_PROMETHEUS_SCRAPE_INTERVAL` |
| `grafana/dockerfile` | Add `ENV GF_PROMETHEUS_SCRAPE_INTERVAL=15s` as fallback default |
| `docker-compose.yml` | Add environment variables to Prometheus and Grafana services |

## Environment Variables

| Variable | Service | Default | Description |
|---|---|---|---|
| `PROMETHEUS_SCRAPE_INTERVAL` | Prometheus | `15s` | How often Prometheus scrapes targets |
| `GF_PROMETHEUS_SCRAPE_INTERVAL` | Grafana | `15s` | Minimum scrape interval shown in Grafana dashboards |
| `PROMETHEUS_FLAGS` | Prometheus | _(empty)_ | Optional runtime flags (e.g. `--web.enable-otlp-receiver`) |

## Notes
- Prometheus does not natively support environment variable expansion in config files (unlike Grafana), so `sed` substitution at container startup is used
- All variables have sensible defaults — existing behavior is unchanged if no variables are set
- `PROMETHEUS_FLAGS` is intentionally not defined in `docker-compose.yml`; it's meant to be set only when needed (e.g. via Railway Variables)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added environment variables to configure Prometheus and Grafana scrape intervals at runtime.
  * Prometheus now reads its scrape interval from an environment variable and starts via an entrypoint that applies that setting.
  * Grafana data source now respects the configured Prometheus scrape interval.

* **Documentation**
  * README updated with new environment-variable options and runtime flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->